### PR TITLE
Fixup building on windows - wrap unix signals in cfg

### DIFF
--- a/rust/src.axum/main.rs
+++ b/rust/src.axum/main.rs
@@ -10,8 +10,9 @@ use std::{
     net::{IpAddr, Ipv4Addr, SocketAddr},
     time::Duration,
 };
+use tokio::signal;
+#[cfg(unix)]
 use tokio::signal::{
-    self,
     unix::{signal, SignalKind},
 };
 use tower::ServiceBuilder;


### PR DESCRIPTION
# Description

Missed a wrapper around a unix signal in the imports. Move that to a cfg so that windows builds can work.

## Link to issue

n/a

## Type of change

- [X] Bug fix (non-breaking change that fixes an issue)

## Test plan (required)

Demonstrate the code is solid. Are changes to the templates tested in the top-level project workflows?

Which commands did you test with and what are the expected results? Which tests have you added or updated? Do the
tests cover all of the changes included in this PR?

`cargo build` on windows 11
